### PR TITLE
Fix "No active EntityManager for name [default], transaction not started?" error

### DIFF
--- a/docker/application.conf
+++ b/docker/application.conf
@@ -4,6 +4,11 @@ application.mode=prod
 application.secret=NOT_GENERATED
 date.format=yyyy-MM-dd
 
+# This plugin disabling workaround is needed for Play! 1.3+ compatibility with Siena
+# I prefer to disable the JPAPlugin, as it was in Play! 1.2.x releases
+# See https://play1-maven-plugin.github.io/play1-maven-plugin/1.0.0-beta8/play-12-to-13-migration.html#Limitations_and_problems_found
+plugins.disable.jpaplugin=play.db.jpa.JPAPlugin
+
 #DB - to prevent Siena trying to connect to Google App Engine
 db=mem
 


### PR DESCRIPTION
Due to change of Play! version the backend node won´t start properly anymore and throws an exception:

```
Can't start in PROD mode with errors

Database error
A database error occured : No active EntityManager for name [default], transaction not started?

play.exceptions.DatabaseException: No active EntityManager for name [default], transaction not started?
	at play.db.DB.getConnection(DB.java:195)
	at play.db.DB.getConnection(DB.java:200)
	at play.modules.siena.PlayConnectionManager.getConnection(PlayConnectionManager.java:16)
	at play.modules.siena.SienaPlugin.onApplicationStart(SienaPlugin.java:138)
	at play.plugins.PluginCollection.onApplicationStart(PluginCollection.java:616)
	at play.Play.start(Play.java:538)
	at play.Play.init(Play.java:309)
	at play.server.Server.main(Server.java:160)
Exception in thread "main" play.exceptions.DatabaseException: No active EntityManager for name [default], transaction not started?
	at play.db.DB.getConnection(DB.java:195)
	at play.db.DB.getConnection(DB.java:200)
	at play.modules.siena.PlayConnectionManager.getConnection(PlayConnectionManager.java:16)
	at play.modules.siena.SienaPlugin.onApplicationStart(SienaPlugin.java:138)
	at play.plugins.PluginCollection.onApplicationStart(PluginCollection.java:616)
	at play.Play.start(Play.java:538)
	at play.Play.init(Play.java:309)
	at play.server.Server.main(Server.java:160)
```