### PR TITLE
Nginx: Remove "ssl" directive and adjust the "listen" directive

### DIFF
--- a/conf/openseedbox-server.nginx.conf
+++ b/conf/openseedbox-server.nginx.conf
@@ -1,8 +1,7 @@
 server {
-	listen 443;
+	listen 443 ssl;
 	server_name node1.openseedbox.com;
 
-	ssl on;
 	ssl_certificate /src/openseedbox-server/conf/host.cert;
 	ssl_certificate_key /src/openseedbox-server/conf/host.key;
 	

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -11,9 +11,8 @@ http {
 	sendfile on;
 
 	server {
-		listen 443;
+		listen 443 ssl;
 
-		ssl on;
 		ssl_certificate /src/openseedbox/conf/host.cert;
 		ssl_certificate_key /src/openseedbox/conf/host.key;
 	


### PR DESCRIPTION
Fix for:

nginx: [warn] the "ssl" directive is deprecated, use the "listen ... ssl" directive instead in /etc/nginx/nginx.conf:16