### PR TITLE
[reverted] TransmissionBackend: fix isRunning (openseedbox/openseedbox#105)

### DIFF
--- a/app/com/openseedbox/backend/transmission/TransmissionBackend.java
+++ b/app/com/openseedbox/backend/transmission/TransmissionBackend.java
@@ -121,7 +121,7 @@ public class TransmissionBackend implements ITorrentBackend {
 		if (pidFile.exists()) {
 			try {
 				String pid = getDaemonPID(pidFile);
-				return !StringUtils.isEmpty(Util.executeCommand("ps -A | grep " + pid).trim());
+				return !StringUtils.isEmpty(Util.executeCommand("ps -A | grep transmission-daemon | grep -w " + pid).trim());
 			} catch (IOException ex) {
 				Logger.error("Unable to read daemon.pid file", ex);
 				return false;


### PR DESCRIPTION
Just grepping for a number in the process list in a non-containerized environment isn't the best way to find out if the backend is running. :wink:

```
$ ps -A | grep 1 | wc -l
361
```

Checking the backend's availibility through RPC is a good point. The initial commit (d8825f07009b) has it as a hint.

Fixes: 98fb99538fcd ("mad progress")
Fixes: openseedbox/openseedbox#105