### PR TITLE
TransmissionBackend: fix isRunning (openseedbox/openseedbox#105)

### DIFF
--- a/app/com/openseedbox/backend/transmission/TransmissionBackend.java
+++ b/app/com/openseedbox/backend/transmission/TransmissionBackend.java
@@ -123,7 +123,7 @@ public class TransmissionBackend implements ITorrentBackend {
 		if (pidFile.exists()) {
 			try {
 				String pid = getDaemonPID(pidFile);
-				return !StringUtils.isEmpty(Util.executeCommand("ps -A | grep " + pid).trim());
+				return binaryName.equals(Util.executeCommand("head -n1 -z /proc/" + pid + "/cmdline").trim());
 			} catch (IOException ex) {
 				Logger.error("Unable to read daemon.pid file", ex);
 				return false;

--- a/test/com/openseedbox/test/backend/TransmissionBackendNotInstalled.java
+++ b/test/com/openseedbox/test/backend/TransmissionBackendNotInstalled.java
@@ -1,0 +1,10 @@
+package com.openseedbox.test.backend;
+
+import com.openseedbox.backend.transmission.TransmissionBackend;
+
+public class TransmissionBackendNotInstalled extends TransmissionBackend {
+
+	public TransmissionBackendNotInstalled() {
+		binaryName = "non-existing-" + super.binaryName;
+	}
+}

--- a/test/com/openseedbox/test/backend/TransmissionBackendNotInstalledTest.java
+++ b/test/com/openseedbox/test/backend/TransmissionBackendNotInstalledTest.java
@@ -1,17 +1,23 @@
 package com.openseedbox.test.backend;
 
+import com.openseedbox.Config;
 import com.openseedbox.backend.transmission.TransmissionBackend;
-import org.junit.Before;
+import org.apache.commons.io.FileUtils;
+import org.junit.AfterClass;
 import org.junit.Test;
 import play.test.UnitTest;
+
+import java.io.File;
+import java.io.IOException;
 
 public class TransmissionBackendNotInstalledTest extends UnitTest {
 
 	private TransmissionBackend backend = new TransmissionBackendNotInstalled();
+	private final static File pidFile = new File(Config.getBackendBasePath(), "daemon.pid");
 
-	@Before
-	public void setUp() {
-
+	@AfterClass
+	public static void tearDown() {
+		pidFile.delete();
 	}
 
 	@Test(expected = RuntimeException.class)
@@ -37,6 +43,18 @@ public class TransmissionBackendNotInstalledTest extends UnitTest {
 	@Test
 	public void testNotInstalled() {
 		assertFalse(backend.isInstalled());
+	}
+
+	@Test
+	public void testNotRunningWithStalePid() {
+		backend.stop();
+		assertFalse(backend.isRunning());
+		try {
+			FileUtils.writeStringToFile(pidFile, "1");
+			assertEquals("1", FileUtils.readFileToString(pidFile));
+		} catch (IOException e) {
+		}
+		assertFalse(backend.isRunning());
 	}
 
 }

--- a/test/com/openseedbox/test/backend/TransmissionBackendNotInstalledTest.java
+++ b/test/com/openseedbox/test/backend/TransmissionBackendNotInstalledTest.java
@@ -1,0 +1,42 @@
+package com.openseedbox.test.backend;
+
+import com.openseedbox.backend.transmission.TransmissionBackend;
+import org.junit.Before;
+import org.junit.Test;
+import play.test.UnitTest;
+
+public class TransmissionBackendNotInstalledTest extends UnitTest {
+
+	private TransmissionBackend backend = new TransmissionBackendNotInstalled();
+
+	@Before
+	public void setUp() {
+
+	}
+
+	@Test(expected = RuntimeException.class)
+	public void testStart() {
+		backend.stop();
+		assertFalse(backend.isRunning());
+		// boom
+		backend.start();
+	}
+
+	@Test
+	public void testNoStart() {
+		try {
+			backend.start();
+		} catch (Exception e) {
+
+		}
+		assertFalse(backend.isRunning());
+		backend.stop();
+		assertFalse(backend.isRunning());
+	}
+
+	@Test
+	public void testNotInstalled() {
+		assertFalse(backend.isInstalled());
+	}
+
+}

--- a/test/com/openseedbox/test/backend/TransmissionBackendTest.java
+++ b/test/com/openseedbox/test/backend/TransmissionBackendTest.java
@@ -1,6 +1,7 @@
 package com.openseedbox.test.backend;
 
 import com.openseedbox.backend.transmission.TransmissionBackend;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import play.test.UnitTest;
@@ -13,7 +14,12 @@ public class TransmissionBackendTest extends UnitTest {
 	public void setUp() {
 
 	}
-	
+
+	@Test
+	public void testInstalled() {
+		assertTrue(backend.isInstalled());
+	}
+
 	@Test
 	public void testStart() {
 		backend.stop();

--- a/test/com/openseedbox/test/backend/TransmissionBackendTest.java
+++ b/test/com/openseedbox/test/backend/TransmissionBackendTest.java
@@ -1,18 +1,29 @@
 package com.openseedbox.test.backend;
 
+import com.openseedbox.Config;
 import com.openseedbox.backend.transmission.TransmissionBackend;
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import play.test.UnitTest;
 
+import java.io.File;
+import java.io.IOException;
+
 public class TransmissionBackendTest extends UnitTest {
 	
 	private TransmissionBackend backend = new TransmissionBackend();
-	
+	private final static File pidFile = new File(Config.getBackendBasePath(), "daemon.pid");
+
 	@Before
 	public void setUp() {
 
+	}
+
+	@AfterClass
+	public static void shutDown() {
+		new TransmissionBackend().stop();
 	}
 
 	@Test
@@ -66,6 +77,17 @@ public class TransmissionBackendTest extends UnitTest {
 	public void testAddTorrentFromFile() {
 		backend.start();
 		
-	}	
-	
+	}
+
+	@Test
+	public void testNotRunningWithStalePid() {
+		backend.stop();
+		assertFalse(backend.isRunning());
+		try {
+			FileUtils.writeStringToFile(pidFile, "1");
+			assertEquals("1", FileUtils.readFileToString(pidFile));
+		} catch (IOException e) {
+		}
+		assertFalse(backend.isRunning());
+	}
 }


### PR DESCRIPTION
(This is a retry of #8)

Just grepping for a number in the process list in a non-containerized environment isn't the best way to find out if the backend is running. ;)

```
$ ps -A | grep 1 | wc -l
361
```

"-w" is for match only whole words. The second grep (for the torrent binary) is for to skip irrelevant results.

Checking the backend's availibility through RPC is a good point. The initial commit (d8825f07009b) has it as a hint. But not for Transmission, which is retardedly slow on slow hard disks (due to IO thread and RPC thread being the same)!
See todo.txt at openseedbox/openseedbox@4b12abd0d75 and transmission/transmission#2462 also!

Fixes: 98fb99538fcd ("mad progress")
Fixes: https://github.com/openseedbox/openseedbox/issues/105